### PR TITLE
Update `checkout` command with new flags and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lgit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lgit"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Peter Luladjiev<lgit-rs@luladjiev.com>"]
 description = "CLI tool for managing git repositories"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,12 @@ pub enum Commands {
     Checkout {
         #[arg(help = "Name of the branch to checkout")]
         name: Option<String>,
+
+        #[arg(short, long, help = "List only remote branches")]
+        remote: bool,
+
+        #[arg(short, long, help = "List all branches (local and remote)")]
+        all: bool,
     },
 
     #[command(about = "Delete all branches for which remotes are gone. Use with caution!")]

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -12,7 +12,7 @@ pub fn run<T: Exec>(
     refresh_base(command, base, verbose).map_err(|()| "Failed to refresh base branch")?;
 
     command
-        .exec(&["checkout", "-b", &name], verbose)
+        .exec(&["checkout", "-b", name], verbose)
         .map_err(|()| "Failed to create branch")?;
 
     if unsaved_changes {

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -3,12 +3,18 @@ use dialoguer::FuzzySelect;
 
 use crate::commands::Exec;
 
-pub fn run<T: Exec>(cmd: &T, name: Option<String>, verbose: bool) -> Result<(), &str> {
+pub fn run<T: Exec>(
+    cmd: &T,
+    name: Option<String>,
+    remote: bool,
+    all: bool,
+    verbose: bool,
+) -> Result<(), &str> {
     if let Some(name) = name {
         return do_checkout(cmd, &name, verbose);
     }
 
-    let branch = get_branches(cmd, verbose)?;
+    let branch = get_branches(cmd, remote, all, verbose)?;
 
     do_checkout(cmd, &branch, verbose)
 }
@@ -20,7 +26,7 @@ fn do_checkout<T: Exec>(cmd: &T, branch: &str, verbose: bool) -> Result<(), &'st
     Ok(())
 }
 
-fn get_branches<T: Exec>(cmd: &T, verbose: bool) -> Result<String, &str> {
+fn get_branches<T: Exec>(cmd: &T, remote: bool, all: bool, verbose: bool) -> Result<String, &str> {
     let remotes: Vec<String> = cmd
         .exec(&["remote"], verbose)
         .map_err(|()| "Failed to get remotes")?
@@ -28,17 +34,28 @@ fn get_branches<T: Exec>(cmd: &T, verbose: bool) -> Result<String, &str> {
         .map(String::from)
         .collect();
 
+    // Determine which branches to list based on flags
+    let branch_args = if all {
+        vec!["branch", "-a", "--format", "%(refname)"]
+    } else if remote {
+        vec!["branch", "-r", "--format", "%(refname)"]
+    } else {
+        vec!["branch", "--format", "%(refname)"]
+    };
+
     let mut branches: Vec<String> = cmd
-        .exec(&["branch", "-a", "--format", "%(refname)"], verbose)
+        .exec(&branch_args, verbose)
         .map_err(|()| "Failed to list branches")?
         .lines()
         .map(|line| {
             let mut line = String::from(line);
 
+            // Clean up remote prefixes
             for remote in &remotes {
                 line = line.replace(&format!("refs/remotes/{}/", &remote), "");
             }
 
+            // Clean up local branch prefix
             line.replace("refs/heads/", "").trim().to_string()
         })
         .filter(|branch| branch != "HEAD")
@@ -46,6 +63,10 @@ fn get_branches<T: Exec>(cmd: &T, verbose: bool) -> Result<String, &str> {
 
     branches.sort();
     branches.dedup();
+
+    if branches.is_empty() {
+        return Err("No branches found");
+    }
 
     let option = FuzzySelect::with_theme(&ColorfulTheme::default())
         .with_prompt("Which branch to checkout?")
@@ -57,13 +78,13 @@ fn get_branches<T: Exec>(cmd: &T, verbose: bool) -> Result<String, &str> {
                 println!("{err}");
             }
 
-            "There was an error determining the commit"
+            "There was an error determining the branch"
         })?;
 
     let branch = branches.get(option);
 
     if branch.is_none() {
-        return Err("There was an error getting the commit");
+        return Err("There was an error getting the branch");
     }
 
     let branch = branch.unwrap();

--- a/src/commands/cherry_pick.rs
+++ b/src/commands/cherry_pick.rs
@@ -27,7 +27,7 @@ pub fn run(cmd: &dyn Exec, branch: &str, number: u32, verbose: bool) -> Result<(
         Ok(commits) => commits,
         Err(err) => {
             if verbose {
-                println!("{}", err);
+                println!("{err}");
             }
 
             return Err("Failed to parse commits format");
@@ -37,7 +37,7 @@ pub fn run(cmd: &dyn Exec, branch: &str, number: u32, verbose: bool) -> Result<(
     selected_commits.reverse();
 
     for commit in selected_commits {
-        if let Err(_) = cmd.exec(&["cherry-pick", commit], verbose) {
+        if cmd.exec(&["cherry-pick", commit], verbose).is_err() {
             return Err("Failed to cherry-pick commit");
         }
     }
@@ -57,11 +57,11 @@ fn get_commits(
                 "log",
                 branch,
                 "--pretty=format:%h %s",
-                &format!("-n {}", number),
+                &format!("-n {number}"),
             ],
             verbose,
         )
-        .map_err(|_| "Failed to get commit history")?;
+        .map_err(|()| "Failed to get commit history")?;
 
     Ok(output.lines().map(String::from).collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,9 @@ fn main() {
 
             branch::run(&command, &name, &base, cli.verbose)
         }
-        Some(Commands::Checkout { name }) => checkout::run(&command, name, cli.verbose),
+        Some(Commands::Checkout { name, remote, all }) => {
+            checkout::run(&command, name, remote, all, cli.verbose)
+        }
         Some(Commands::DeleteBranches { dry_run }) => {
             delete_branches::run(&command, dry_run, cli.verbose)
         }


### PR DESCRIPTION
Enhance the `checkout` command by adding the `--remote` and `--all` flags for improved branching and remote handling. The update also refines error messages for a better user experience.